### PR TITLE
Seting action :nothing for ruby_block[bundle_unicorn]

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,6 +65,7 @@ ruby_block "bundle_unicorn" do
     File.exists?(File.join(node.gdash.base, 'Gemfile')) &&
     File.read(File.join(node.gdash.base, 'Gemfile')).include?('unicorn')
   end
+  action :nothing
 end
 
 directory File.join(node.gdash.base, 'graph_templates', 'dashboards') do


### PR DESCRIPTION
Currently the chef run explodes because this ruby_block runs prematurely. Setting action :nothing allows it to be notified by the untar execute resource as it seems was intended.
